### PR TITLE
fix: use Dispatcharr tvc_guide_stationid for scan-missing-listings

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2739,6 +2739,63 @@ def get_emby_channels():
         logger.error(f"Error getting Emby channels: {e}")
         return jsonify({'error': str(e)}), 500
 
+def _load_dispatcharr_station_ids():
+    """Load tvc_guide_stationid from Dispatcharr channels, keyed by name and number.
+
+    Returns a dict with composite keys:
+        ('name', <lowercase name>) -> station_id
+        ('number', <channel number string>) -> station_id
+    so the caller can look up by either.  Returns empty dict if Dispatcharr
+    is not configured or unreachable.
+    """
+    try:
+        settings = settings_manager.load_settings()
+        d = settings.get('dispatcharr', {})
+        d_url = (d.get('url') or '').rstrip('/')
+        d_user = d.get('username')
+        d_pass = d.get('password')
+
+        if not all([d_url, d_user, d_pass]):
+            return {}
+
+        channels_data = []
+        channels_url = '/api/channels/channels/'
+        while channels_url:
+            data, error = dispatcharr_api_request(d_url, d_user, d_pass, 'GET', channels_url)
+            if error or not data:
+                break
+            if isinstance(data, dict) and 'results' in data:
+                channels_data.extend(data['results'])
+                next_url = data.get('next')
+                if next_url:
+                    import urllib.parse
+                    parsed = urllib.parse.urlparse(next_url)
+                    channels_url = f"{parsed.path}?{parsed.query}" if parsed.query else parsed.path
+                else:
+                    channels_url = None
+            elif isinstance(data, list):
+                channels_data.extend(data)
+                channels_url = None
+            else:
+                channels_url = None
+
+        lookup = {}
+        for ch in channels_data:
+            sid = ch.get('tvc_guide_stationid')
+            if not sid:
+                continue
+            name = (ch.get('name') or '').strip().lower()
+            number = str(ch.get('channel_number') or '').strip()
+            if name:
+                lookup[('name', name)] = str(sid)
+            if number:
+                lookup[('number', number)] = str(sid)
+        return lookup
+
+    except Exception as e:
+        logger.warning(f"Could not load Dispatcharr station IDs: {e}")
+        return {}
+
 @app.route('/api/emby/scan-missing-listings', methods=['POST'])
 def scan_emby_missing_listings():
     """Scan Emby channels for missing ListingsId and add providers with intelligent lineup selection"""
@@ -2769,9 +2826,32 @@ def scan_emby_missing_listings():
         if not missing_channels:
             return jsonify({'providers_added': 0, 'message': 'All channels have ListingsId'}), 200
 
-        # Extract station IDs from ManagementId
+        # Extract station IDs — prefer Dispatcharr's tvc_guide_stationid when
+        # available, fall back to ManagementId parsing for M3U tuner channels.
+        #
+        # ManagementId parsing only works for M3U tuners (where the last segment
+        # is the tvg-id / Gracenote station ID).  Custom tuners (e.g. Xtream)
+        # put an internal stream ID there instead, which can collide with real
+        # Gracenote station IDs and cause dozens of wrong lineups to be added.
         station_ids = set()
+
+        dispatcharr_station_ids = _load_dispatcharr_station_ids()
+        if dispatcharr_station_ids:
+            logger.info(f"Loaded {len(dispatcharr_station_ids)} station IDs from Dispatcharr")
+
         for ch in missing_channels:
+            ch_name = (ch.get('Name') or '').strip().lower()
+            ch_number = str(ch.get('ChannelNumber') or '').strip()
+
+            # Try Dispatcharr lookup first (by name, then by channel number)
+            matched_station_id = dispatcharr_station_ids.get(('name', ch_name)) \
+                or dispatcharr_station_ids.get(('number', ch_number))
+
+            if matched_station_id:
+                station_ids.add(matched_station_id)
+                continue
+
+            # Fallback: parse ManagementId (works for M3U tuner channels)
             mgmt_id = ch.get('ManagementId', '')
             if mgmt_id and '_' in mgmt_id:
                 station_id = mgmt_id.split('_')[-1]

--- a/backend/app.py
+++ b/backend/app.py
@@ -2826,37 +2826,40 @@ def scan_emby_missing_listings():
         if not missing_channels:
             return jsonify({'providers_added': 0, 'message': 'All channels have ListingsId'}), 200
 
-        # Extract station IDs — prefer Dispatcharr's tvc_guide_stationid when
-        # available, fall back to ManagementId parsing for M3U tuner channels.
+        # Extract station IDs from one of two mutually exclusive sources:
         #
-        # ManagementId parsing only works for M3U tuners (where the last segment
-        # is the tvg-id / Gracenote station ID).  Custom tuners (e.g. Xtream)
-        # put an internal stream ID there instead, which can collide with real
-        # Gracenote station IDs and cause dozens of wrong lineups to be added.
+        # 1. Dispatcharr (preferred): cross-reference by channel name/number to
+        #    get tvc_guide_stationid — the real Gracenote station ID.
+        # 2. ManagementId parsing (legacy): split on '_' and take the last
+        #    segment.  Only valid for M3U tuners where that segment is tvg-id.
+        #
+        # These two paths are mutually exclusive.  When Dispatcharr is configured
+        # and returns data, ManagementId parsing is completely disabled — even for
+        # channels that don't match by name/number.  This prevents custom tuners
+        # (e.g. Xtream) whose ManagementId contains an internal stream ID from
+        # polluting the station set with phantom Gracenote IDs.
         station_ids = set()
 
         dispatcharr_station_ids = _load_dispatcharr_station_ids()
-        if dispatcharr_station_ids:
-            logger.info(f"Loaded {len(dispatcharr_station_ids)} station IDs from Dispatcharr")
+        dispatcharr_available = len(dispatcharr_station_ids) > 0
+
+        if dispatcharr_available:
+            logger.info(f"Loaded {len(dispatcharr_station_ids)} Dispatcharr entries — using as sole station ID source")
 
         for ch in missing_channels:
-            ch_name = (ch.get('Name') or '').strip().lower()
-            ch_number = str(ch.get('ChannelNumber') or '').strip()
-
-            # Try Dispatcharr lookup first (by name, then by channel number)
-            matched_station_id = dispatcharr_station_ids.get(('name', ch_name)) \
-                or dispatcharr_station_ids.get(('number', ch_number))
-
-            if matched_station_id:
-                station_ids.add(matched_station_id)
-                continue
-
-            # Fallback: parse ManagementId (works for M3U tuner channels)
-            mgmt_id = ch.get('ManagementId', '')
-            if mgmt_id and '_' in mgmt_id:
-                station_id = mgmt_id.split('_')[-1]
-                if station_id.isdigit() and len(station_id) >= 4:
-                    station_ids.add(station_id)
+            if dispatcharr_available:
+                ch_name = (ch.get('Name') or '').strip().lower()
+                ch_number = str(ch.get('ChannelNumber') or '').strip()
+                matched = dispatcharr_station_ids.get(('name', ch_name)) \
+                    or dispatcharr_station_ids.get(('number', ch_number))
+                if matched:
+                    station_ids.add(matched)
+            else:
+                mgmt_id = ch.get('ManagementId', '')
+                if mgmt_id and '_' in mgmt_id:
+                    station_id = mgmt_id.split('_')[-1]
+                    if station_id.isdigit() and len(station_id) >= 4:
+                        station_ids.add(station_id)
 
         if not station_ids:
             return jsonify({'error': 'No valid station IDs found'}), 400


### PR DESCRIPTION
## Summary

Fixes #6 — "Scan Missing Listings" adds excessive EPG providers for custom tuner channels (non-M3U).

- When Dispatcharr is configured, cross-references channels by name/number to get the real `tvc_guide_stationid` instead of parsing ManagementId
- Falls back to existing ManagementId parsing when Dispatcharr is not configured (backward compatible for M3U-only setups)
- **The Dispatcharr path and ManagementId path are mutually exclusive** — when Dispatcharr returns data, ManagementId parsing is completely disabled, even for channels that don't match by name/number

## Problem

The `scan-missing-listings` endpoint extracts station IDs from Emby's `ManagementId` by splitting on `_` and taking the last segment. For M3U tuners this is the `tvg-id` (= Gracenote station ID), but for custom tuners (e.g. Xtream Tuner plugin) it's an internal stream ID like `14035`.

Since stream IDs and Gracenote station IDs are both large integers, collisions cause the set-cover algorithm to find dozens of irrelevant regional lineups — e.g. **42 providers added for only 21 channels** with Gracenote IDs.

## How it works

New helper `_load_dispatcharr_station_ids()`:
1. Reads Dispatcharr credentials from the settings manager
2. Fetches all Dispatcharr channels (with pagination support)
3. Builds a lookup keyed by `(name, <lowercase>)` and `(number, <channel_number>)` → `tvc_guide_stationid`

In the scan endpoint, the two resolution strategies are **mutually exclusive**:

- **Dispatcharr available** (lookup returned data): for each Emby channel, try matching by name then by channel number against the Dispatcharr lookup. Use `tvc_guide_stationid` if matched; skip the channel entirely if not. ManagementId is never touched.
- **Dispatcharr not available** (no config, unreachable, or no data): fall back to existing ManagementId parsing (works for M3U tuner channels).

### Why mutual exclusion?

The initial implementation used a per-channel fallback: try Dispatcharr first, then fall back to ManagementId for unmatched channels. Testing by Moonshine revealed this was still broken — channels with slight naming differences between Emby and Dispatcharr fell through to ManagementId parsing, pulling in stream IDs as phantom Gracenote station IDs.

The mutual-exclusion approach eliminates this entirely: if Dispatcharr is the source of truth, channels that don't match simply don't get a station ID (they fall back to the tuner's own EPG via the plugin). This is the correct behavior.

## Test plan

- [ ] M3U-only setup (no Dispatcharr configured): behavior unchanged, ManagementId parsing still works
- [ ] Dispatcharr + Xtream tuner: only channels with `tvc_guide_stationid` that match by name/number get station IDs; no phantom matches from stream IDs
- [ ] Dispatcharr + M3U tuner: station IDs come from Dispatcharr where matched
- [ ] Dispatcharr configured but unreachable: falls back to ManagementId parsing gracefully

## Credits

Thanks to **Moonshine** for testing the initial PR and identifying the per-channel fallback issue — the mutual-exclusion fix was designed based on their findings.