### PR TITLE
fix: make scan-missing-listings idempotent and skip ListingsId filter for Dispatcharr setups

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2820,33 +2820,30 @@ def scan_emby_missing_listings():
 
         channels = result if isinstance(result, list) else result.get('Items', [])
 
-        # Find channels missing ListingsId
-        missing_channels = [ch for ch in channels if not ch.get('ListingsId')]
-
-        if not missing_channels:
-            return jsonify({'providers_added': 0, 'message': 'All channels have ListingsId'}), 200
-
-        # Extract station IDs from one of two mutually exclusive sources:
+        # Determine station ID source and which channels to process.
         #
-        # 1. Dispatcharr (preferred): cross-reference by channel name/number to
-        #    get tvc_guide_stationid — the real Gracenote station ID.
-        # 2. ManagementId parsing (legacy): split on '_' and take the last
-        #    segment.  Only valid for M3U tuners where that segment is tvg-id.
-        #
-        # These two paths are mutually exclusive.  When Dispatcharr is configured
-        # and returns data, ManagementId parsing is completely disabled — even for
-        # channels that don't match by name/number.  This prevents custom tuners
-        # (e.g. Xtream) whose ManagementId contains an internal stream ID from
-        # polluting the station set with phantom Gracenote IDs.
-        station_ids = set()
-
+        # Two mutually exclusive paths:
+        #   1. Dispatcharr (preferred): cross-reference by name/number to get
+        #      tvc_guide_stationid.  When available, ListingsId filtering is
+        #      skipped because custom tuners (e.g. Xtream) always have empty
+        #      ListingsId -- filtering by it is meaningless.
+        #   2. ManagementId parsing (legacy): split on '_' and take the last
+        #      segment.  Only valid for M3U tuners where that segment is tvg-id.
+        #      Uses the traditional ListingsId filter to find unprocessed channels.
         dispatcharr_station_ids = _load_dispatcharr_station_ids()
         dispatcharr_available = len(dispatcharr_station_ids) > 0
 
         if dispatcharr_available:
-            logger.info(f"Loaded {len(dispatcharr_station_ids)} Dispatcharr entries — using as sole station ID source")
+            target_channels = channels
+            logger.info(f"Loaded {len(dispatcharr_station_ids)} Dispatcharr entries, processing all {len(channels)} channels")
+        else:
+            target_channels = [ch for ch in channels if not ch.get('ListingsId')]
+            if not target_channels:
+                return jsonify({'providers_added': 0, 'message': 'All channels have ListingsId'}), 200
+            logger.info(f"No Dispatcharr config, filtering by ListingsId: {len(target_channels)} channels missing")
 
-        for ch in missing_channels:
+        station_ids = set()
+        for ch in target_channels:
             if dispatcharr_available:
                 ch_name = (ch.get('Name') or '').strip().lower()
                 ch_number = str(ch.get('ChannelNumber') or '').strip()
@@ -2860,6 +2857,8 @@ def scan_emby_missing_listings():
                     station_id = mgmt_id.split('_')[-1]
                     if station_id.isdigit() and len(station_id) >= 4:
                         station_ids.add(station_id)
+
+        logger.info(f"Resolved {len(station_ids)} unique Gracenote station IDs")
 
         if not station_ids:
             return jsonify({'error': 'No valid station IDs found'}), 400
@@ -2974,17 +2973,38 @@ def scan_emby_missing_listings():
         if not selected_lineups:
             return jsonify({'error': 'No lineups found for the specified stations'}), 404
 
+        # Fetch existing listing providers so we can skip duplicates
+        existing_lineup_ids = set()
+        existing_result, _ = emby_api_request(url, token, 'GET', '/emby/LiveTv/ListingProviders')
+        if existing_result and isinstance(existing_result, list):
+            for p in existing_result:
+                lid = p.get('ListingsId')
+                if lid:
+                    existing_lineup_ids.add(lid)
+
+        new_lineups = {k: v for k, v in selected_lineups.items() if k not in existing_lineup_ids}
+        skipped_lineups = len(selected_lineups) - len(new_lineups)
+
+        if skipped_lineups > 0:
+            logger.info(f"Skipping {skipped_lineups} lineup(s) already in Emby, adding {len(new_lineups)} new")
+
+        if not new_lineups:
+            return jsonify({
+                'providers_added': 0,
+                'providers_skipped': skipped_lineups,
+                'message': f'All {len(selected_lineups)} selected lineups already exist in Emby'
+            }), 200
+
         # Add listing providers to Emby with SSE progress
         def generate():
             providers_added = 0
             providers_failed = 0
-            total_lineups = len(selected_lineups)
+            total_lineups = len(new_lineups)
             current = 0
 
-            for lineup_id, lineup_info in selected_lineups.items():
+            for lineup_id, lineup_info in new_lineups.items():
                 current += 1
 
-                # Send progress update
                 yield f"data: {json.dumps({'progress': current, 'total': total_lineups, 'lineup': lineup_info['name'], 'lineup_id': lineup_id})}\n\n"
 
                 provider_data = {
@@ -2996,17 +3016,17 @@ def scan_emby_missing_listings():
 
                 result, error = emby_api_request(url, token, 'POST', '/emby/LiveTv/ListingProviders', provider_data)
 
-                if result is not None:  # Success includes empty dict
+                if result is not None:
                     providers_added += 1
                 else:
                     providers_failed += 1
                     logger.warning(f"Failed to add provider {lineup_id}: {error}")
 
-            # Send completion
             completion_data = {
                 'done': True,
                 'providers_added': providers_added,
                 'providers_failed': providers_failed,
+                'providers_skipped': skipped_lineups,
                 'total_stations': len(station_ids),
                 'lineups_selected': list(selected_lineups.keys())
             }

--- a/backend/app.py
+++ b/backend/app.py
@@ -2739,6 +2739,63 @@ def get_emby_channels():
         logger.error(f"Error getting Emby channels: {e}")
         return jsonify({'error': str(e)}), 500
 
+def _load_dispatcharr_station_ids():
+    """Load tvc_guide_stationid from Dispatcharr channels, keyed by name and number.
+
+    Returns a dict with composite keys:
+        ('name', <lowercase name>) -> station_id
+        ('number', <channel number string>) -> station_id
+    so the caller can look up by either.  Returns empty dict if Dispatcharr
+    is not configured or unreachable.
+    """
+    try:
+        settings = settings_manager.load_settings()
+        d = settings.get('dispatcharr', {})
+        d_url = (d.get('url') or '').rstrip('/')
+        d_user = d.get('username')
+        d_pass = d.get('password')
+
+        if not all([d_url, d_user, d_pass]):
+            return {}
+
+        channels_data = []
+        channels_url = '/api/channels/channels/'
+        while channels_url:
+            data, error = dispatcharr_api_request(d_url, d_user, d_pass, 'GET', channels_url)
+            if error or not data:
+                break
+            if isinstance(data, dict) and 'results' in data:
+                channels_data.extend(data['results'])
+                next_url = data.get('next')
+                if next_url:
+                    import urllib.parse
+                    parsed = urllib.parse.urlparse(next_url)
+                    channels_url = f"{parsed.path}?{parsed.query}" if parsed.query else parsed.path
+                else:
+                    channels_url = None
+            elif isinstance(data, list):
+                channels_data.extend(data)
+                channels_url = None
+            else:
+                channels_url = None
+
+        lookup = {}
+        for ch in channels_data:
+            sid = ch.get('tvc_guide_stationid')
+            if not sid:
+                continue
+            name = (ch.get('name') or '').strip().lower()
+            number = str(ch.get('channel_number') or '').strip()
+            if name:
+                lookup[('name', name)] = str(sid)
+            if number:
+                lookup[('number', number)] = str(sid)
+        return lookup
+
+    except Exception as e:
+        logger.warning(f"Could not load Dispatcharr station IDs: {e}")
+        return {}
+
 @app.route('/api/emby/scan-missing-listings', methods=['POST'])
 def scan_emby_missing_listings():
     """Scan Emby channels for missing ListingsId and add providers with intelligent lineup selection"""
@@ -2769,9 +2826,32 @@ def scan_emby_missing_listings():
         if not missing_channels:
             return jsonify({'providers_added': 0, 'message': 'All channels have ListingsId'}), 200
 
-        # Extract station IDs from ManagementId
+        # Extract station IDs — prefer Dispatcharr's tvc_guide_stationid when
+        # available, fall back to ManagementId parsing for M3U tuner channels.
+        #
+        # ManagementId parsing only works for M3U tuners (where the last segment
+        # is the tvg-id / Gracenote station ID).  Custom tuners (e.g. Xtream)
+        # put an internal stream ID there instead, which can collide with real
+        # Gracenote station IDs and cause dozens of wrong lineups to be added.
         station_ids = set()
+
+        dispatcharr_station_ids = _load_dispatcharr_station_ids()
+        if dispatcharr_station_ids:
+            logger.info(f"Loaded {len(dispatcharr_station_ids)} station IDs from Dispatcharr")
+
         for ch in missing_channels:
+            ch_name = (ch.get('Name') or '').strip().lower()
+            ch_number = str(ch.get('ChannelNumber') or '').strip()
+
+            # Try Dispatcharr lookup first (by name, then by channel number)
+            matched_station_id = dispatcharr_station_ids.get(('name', ch_name)) \
+                or dispatcharr_station_ids.get(('number', ch_number))
+
+            if matched_station_id:
+                station_ids.add(matched_station_id)
+                continue
+
+            # Fallback: parse ManagementId (works for M3U tuner channels)
             mgmt_id = ch.get('ManagementId', '')
             if mgmt_id and '_' in mgmt_id:
                 station_id = mgmt_id.split('_')[-1]

--- a/backend/app.py
+++ b/backend/app.py
@@ -2826,37 +2826,40 @@ def scan_emby_missing_listings():
         if not missing_channels:
             return jsonify({'providers_added': 0, 'message': 'All channels have ListingsId'}), 200
 
-        # Extract station IDs — prefer Dispatcharr's tvc_guide_stationid when
-        # available, fall back to ManagementId parsing for M3U tuner channels.
+        # Extract station IDs from one of two mutually exclusive sources:
         #
-        # ManagementId parsing only works for M3U tuners (where the last segment
-        # is the tvg-id / Gracenote station ID).  Custom tuners (e.g. Xtream)
-        # put an internal stream ID there instead, which can collide with real
-        # Gracenote station IDs and cause dozens of wrong lineups to be added.
+        # 1. Dispatcharr (preferred): cross-reference by channel name/number to
+        #    get tvc_guide_stationid — the real Gracenote station ID.
+        # 2. ManagementId parsing (legacy): split on '_' and take the last
+        #    segment.  Only valid for M3U tuners where that segment is tvg-id.
+        #
+        # These two paths are mutually exclusive.  When Dispatcharr is configured
+        # and returns data, ManagementId parsing is completely disabled — even for
+        # channels that don't match by name/number.  This prevents custom tuners
+        # (e.g. Xtream) whose ManagementId contains an internal stream ID from
+        # polluting the station set with phantom Gracenote IDs.
         station_ids = set()
 
         dispatcharr_station_ids = _load_dispatcharr_station_ids()
-        if dispatcharr_station_ids:
-            logger.info(f"Loaded {len(dispatcharr_station_ids)} station IDs from Dispatcharr")
+        dispatcharr_available = len(dispatcharr_station_ids) > 0
+
+        if dispatcharr_available:
+            logger.info(f"Loaded {len(dispatcharr_station_ids)} Dispatcharr entries — using as sole station ID source")
 
         for ch in missing_channels:
-            ch_name = (ch.get('Name') or '').strip().lower()
-            ch_number = str(ch.get('ChannelNumber') or '').strip()
-
-            # Try Dispatcharr lookup first (by name, then by channel number)
-            matched_station_id = dispatcharr_station_ids.get(('name', ch_name)) \
-                or dispatcharr_station_ids.get(('number', ch_number))
-
-            if matched_station_id:
-                station_ids.add(matched_station_id)
-                continue
-
-            # Fallback: parse ManagementId (works for M3U tuner channels)
-            mgmt_id = ch.get('ManagementId', '')
-            if mgmt_id and '_' in mgmt_id:
-                station_id = mgmt_id.split('_')[-1]
-                if station_id.isdigit() and len(station_id) >= 4:
-                    station_ids.add(station_id)
+            if dispatcharr_available:
+                ch_name = (ch.get('Name') or '').strip().lower()
+                ch_number = str(ch.get('ChannelNumber') or '').strip()
+                matched = dispatcharr_station_ids.get(('name', ch_name)) \
+                    or dispatcharr_station_ids.get(('number', ch_number))
+                if matched:
+                    station_ids.add(matched)
+            else:
+                mgmt_id = ch.get('ManagementId', '')
+                if mgmt_id and '_' in mgmt_id:
+                    station_id = mgmt_id.split('_')[-1]
+                    if station_id.isdigit() and len(station_id) >= 4:
+                        station_ids.add(station_id)
 
         if not station_ids:
             return jsonify({'error': 'No valid station IDs found'}), 400


### PR DESCRIPTION
## Summary

Fixes #8 -- re-running "Scan Missing Listings" no longer adds duplicate providers, and the ListingsId filter is bypassed when Dispatcharr is the station ID source.

- Fetches existing `embygn` providers from Emby before adding new ones; skips any lineup that already exists
- When Dispatcharr is configured, processes all channels instead of filtering by `ListingsId` (which is always empty for custom tuners like Xtream)
- Adds `providers_skipped` to the response so the UI can show how many were already present

**Depends on #7** (uses `_load_dispatcharr_station_ids()` helper and mutual-exclusion logic). Should be merged after #7.

## Problem

For setups using the Xtream Tuner Plugin, `ListingsId` is always empty because the plugin intentionally detaches listing providers (to prevent Emby's auto-mapper from incorrectly mapping Gracenote to all channels). This means:

1. Every channel appears as "missing" on every scan run
2. The set-cover algorithm recomputes the full optimal lineup set every time
3. No duplicate detection: re-running adds the same lineups again

Users have to manually clear all EPG sources in Emby before re-running the scan, even when just adding a few new channels.

## How it works

### Skip duplicate providers (Fix A)

Before the POST loop, fetches `GET /emby/LiveTv/ListingProviders` and builds a set of existing `ListingsId` values. Any lineup selected by set-cover that already exists is filtered out. Only genuinely new lineups are added.

### Use Dispatcharr as channel filter (Fix D)

When Dispatcharr is configured and returns data, the `ListingsId` filter is skipped entirely. All channels are processed, but only those matched in the Dispatcharr lookup (by name or channel number) contribute station IDs. This is the correct behavior since the Dispatcharr lookup is already the source of truth for station IDs.

For setups without Dispatcharr, the existing `ListingsId` filter is preserved (backward compatible).

## Test plan

- [ ] First run: adds correct lineups (same as before)
- [ ] Second run (no changes): reports all lineups already exist, adds nothing
- [ ] Add new channels in Dispatcharr, then re-run: only adds new lineup(s) needed for the new stations
- [ ] No Dispatcharr configured: ListingsId filter still works as before
- [ ] Response includes `providers_skipped` count

## Credits

Based on testing feedback from **Moonshine** who identified the re-run workflow issue.

Made with [Cursor](https://cursor.com)