### PR TITLE
Fix channel number matching: normalize decimals (117.0 → 117)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -80,6 +80,16 @@ def dict_from_row(row):
     """Convert SQLite Row to dictionary"""
     return dict(zip(row.keys(), row))
 
+def normalize_channel_number(num):
+    """Normalize channel number for comparison: 117.0 -> '117', 2.1 -> '2.1'"""
+    try:
+        f = float(num)
+        if f == int(f):
+            return str(int(f))
+        return str(f)
+    except (ValueError, TypeError):
+        return str(num) if num else ''
+
 def parse_channel_name(channel_name):
     """
     Parse channel name to extract country, resolution, and clean name.
@@ -1178,9 +1188,9 @@ def import_lineup(lineup_id):
             # Apply channel offset
             try:
                 original_num = float(channel_data['channel_number'])
-                channel_data['final_channel_number'] = str(original_num + channel_offset)
+                channel_data['final_channel_number'] = normalize_channel_number(original_num + channel_offset)
             except:
-                channel_data['final_channel_number'] = channel_data['channel_number']
+                channel_data['final_channel_number'] = normalize_channel_number(channel_data['channel_number'])
             channels_to_import.append(channel_data)
 
         conn.close()
@@ -1212,7 +1222,7 @@ def import_lineup(lineup_id):
         existing_by_number = {}
         existing_by_station_id = {}
         for ch in existing_channels:
-            ch_num = str(ch.get('channel_number', ''))
+            ch_num = normalize_channel_number(ch.get('channel_number', ''))
             if ch_num:
                 if ch_num not in existing_by_number:
                     existing_by_number[ch_num] = []
@@ -1933,7 +1943,7 @@ def get_dispatcharr_channels():
 
                 channel = {
                     'id': ch.get('id'),
-                    'channel_number': ch.get('channel_number', 0),
+                    'channel_number': normalize_channel_number(ch.get('channel_number', 0)),
                     'name': ch.get('name'),
                     'call_sign': ch.get('tvg_id', ''),  # TVG ID is often used as call sign
                     'gracenote_id': ch.get('tvc_guide_stationid', ''),


### PR DESCRIPTION
## Summary

- Adds `normalize_channel_number()` helper that converts `117.0` → `"117"` while preserving real decimals like `2.1` → `"2.1"`
- Applies normalization in Clone Lineup's `existing_by_number` lookup, `final_channel_number` computation, and the Dispatcharr channels endpoint response

## Problem

Dispatcharr returns `channel_number` as a float (e.g. `117.0`). When converted to a string with `str()`, this becomes `"117.0"`. Emby's `ChannelNumber` is `"117"`. The string mismatch causes channel number matching to silently fail for every whole-number channel — which is the vast majority.

This was reported by a tester using the Xtream Tuner Plugin with Dispatcharr. The plugin's name filters also alter channel display names, so the name-based fallback doesn't help either. Fixing number normalization resolves both paths.

## Changes

| File | Change |
|---|---|
| `backend/app.py` | Add `normalize_channel_number()` utility function |
| `backend/app.py` (~L1225) | Normalize `existing_by_number` keys in Clone Lineup |
| `backend/app.py` (~L1191) | Normalize `final_channel_number` after offset calculation |
| `backend/app.py` (~L1946) | Normalize `channel_number` in Dispatcharr channels response |

Fixes #10

Made with [Cursor](https://cursor.com)